### PR TITLE
feat: add dark mode hook

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,21 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { useDarkMode } from "@/hooks/useDarkMode";
 
 export default function Home() {
   const [todos, setTodos] = useState<string[]>([]);
   const [input, setInput] = useState("");
-  const [darkMode, setDarkMode] = useState(false);
-
-  useEffect(() => {
-    if (darkMode) {
-      document.documentElement.classList.add("dark");
-    } else {
-      document.documentElement.classList.remove("dark");
-    }
-  }, [darkMode]);
-
-  const toggleDarkMode = () => setDarkMode((prev) => !prev);
+  const { theme, toggleTheme } = useDarkMode();
 
   const addTodo = () => {
     if (!input.trim()) return;
@@ -31,11 +22,11 @@ export default function Home() {
     <main className="relative flex min-h-screen flex-col items-center justify-center bg-gray-100 dark:bg-gray-900 text-text p-4">
       <button
         type="button"
-        onClick={toggleDarkMode}
+        onClick={toggleTheme}
         className="absolute top-4 right-4"
-        aria-label="toggle dark mode"
+        aria-label="toggle theme"
       >
-        {darkMode ? (
+        {theme === "dark" ? (
           <svg
             className="h-6 w-6 text-yellow-400"
             viewBox="0 0 24 24"
@@ -47,7 +38,7 @@ export default function Home() {
           >
             <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
           </svg>
-        ) : (
+        ) : theme === "light" ? (
           <svg
             className="h-6 w-6 text-red-500"
             viewBox="0 0 24 24"
@@ -59,6 +50,20 @@ export default function Home() {
           >
             <circle cx="12" cy="12" r="5" />
             <path d="M12 1v2m0 18v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2m18 0h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+          </svg>
+        ) : (
+          <svg
+            className="h-6 w-6 text-green-500"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
+            <line x1="8" y1="21" x2="16" y2="21" />
+            <line x1="12" y1="17" x2="12" y2="21" />
           </svg>
         )}
       </button>

--- a/hooks/useDarkMode.ts
+++ b/hooks/useDarkMode.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+
+type Theme = "light" | "dark" | "system";
+
+export function useDarkMode() {
+  const [theme, setTheme] = useState<Theme>("system");
+
+  // Load stored preference
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = localStorage.getItem("theme") as Theme | null;
+    if (stored) {
+      setTheme(stored);
+    }
+  }, []);
+
+  // Apply theme and persist
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const root = document.documentElement;
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+    const applyTheme = (t: Theme) => {
+      const effective =
+        t === "system" ? (mediaQuery.matches ? "dark" : "light") : t;
+      if (effective === "dark") {
+        root.classList.add("dark");
+      } else {
+        root.classList.remove("dark");
+      }
+    };
+
+    applyTheme(theme);
+    localStorage.setItem("theme", theme);
+
+    if (theme === "system") {
+      const handler = () => applyTheme("system");
+      mediaQuery.addEventListener("change", handler);
+      return () => mediaQuery.removeEventListener("change", handler);
+    }
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) =>
+      prev === "light" ? "dark" : prev === "dark" ? "system" : "light"
+    );
+  };
+
+  return { theme, setTheme, toggleTheme };
+}


### PR DESCRIPTION
## Summary
- add `useDarkMode` hook to persist user theme preference and react to system changes
- switch todo page to new hook and show icons for light, dark, and system themes

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c0c7fba4fc8325a02e4a20914594f4