### PR TITLE
Add class-based dark mode support and accessibility

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -22,6 +22,12 @@
   }
 }
 
+html.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+  --text: #ededed;
+}
+
 body {
   @apply bg-background text-text;
   font-family: Arial, Helvetica, sans-serif;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,6 +24,23 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(() => {
+  try {
+    const theme = localStorage.getItem('theme');
+    const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (theme === 'dark' || (!theme && systemDark)) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  } catch (_) {}
+})();`,
+          }}
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,7 +24,8 @@ export default function Home() {
         type="button"
         onClick={toggleTheme}
         className="absolute top-4 right-4"
-        aria-label="toggle theme"
+        aria-pressed={theme === "dark"}
+        aria-label={theme === "dark" ? "switch to light theme" : "switch to dark theme"}
       >
         {theme === "dark" ? (
           <svg
@@ -66,6 +67,9 @@ export default function Home() {
             <line x1="12" y1="17" x2="12" y2="21" />
           </svg>
         )}
+        <span className="sr-only">
+          {theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}
+        </span>
       </button>
 
       <h1 className="text-3xl font-bold mb-6 text-text">Todo List</h1>

--- a/hooks/useDarkMode.ts
+++ b/hooks/useDarkMode.ts
@@ -35,8 +35,24 @@ export function useDarkMode() {
 
     if (theme === "system") {
       const handler = () => applyTheme("system");
-      mediaQuery.addEventListener("change", handler);
-      return () => mediaQuery.removeEventListener("change", handler);
+      if (typeof mediaQuery.addEventListener === "function") {
+        mediaQuery.addEventListener("change", handler);
+        return () => mediaQuery.removeEventListener("change", handler);
+      } else if (
+        typeof (
+          mediaQuery as MediaQueryList & {
+            addListener?: (listener: (e: MediaQueryListEvent) => void) => void;
+            removeListener?: (listener: (e: MediaQueryListEvent) => void) => void;
+          }
+        ).addListener === "function"
+      ) {
+        const legacy = mediaQuery as MediaQueryList & {
+          addListener: (listener: (e: MediaQueryListEvent) => void) => void;
+          removeListener: (listener: (e: MediaQueryListEvent) => void) => void;
+        };
+        legacy.addListener(handler);
+        return () => legacy.removeListener(handler);
+      }
     }
   }, [theme]);
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,8 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: "class",
+  content: ["./app/**/*.{ts,tsx}", "./hooks/**/*.{ts,tsx}"],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- Support `html.dark` override for CSS variables
- Enable class-based dark mode in Tailwind configuration
- Apply persisted theme before paint and improve theme toggle accessibility
- Add cross-browser matchMedia listener fallback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0cb0699b48325bf8ea46ffba8827c