### PR TITLE
Fix light theme when dark class missing

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -14,14 +14,6 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-    --text: #ededed;
-  }
-}
-
 html.dark {
   --background: #0a0a0a;
   --foreground: #ededed;


### PR DESCRIPTION
## Summary
- remove prefers-color-scheme dark media query so light variables apply when `html` lacks `dark`

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*


------
https://chatgpt.com/codex/tasks/task_e_68c10629cc3c8325bbc6fd29737400bc